### PR TITLE
feat: Tarea 7.1: Módulo de Categorías

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { LoggerModule } from './common/utils/logger.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { UsersModule } from './modules/users/users.module';
 import { ProductsModule } from './modules/products/products.module';
+import { CategoriesModule } from './modules/categories/categories.module';
 // import { OrdersModule } from './modules/orders/orders.module';
 // import { InventoryModule } from './modules/inventory/inventory.module';
 // import { PaymentsModule } from './modules/payments/payments.module';
@@ -73,6 +74,7 @@ import { HealthModule } from './health/health.module';
     AuthModule,
     UsersModule,
     ProductsModule,
+    CategoriesModule,
 
     // TODO: Add modules as they are developed
     // OrdersModule,

--- a/src/database/migrations/1727220000000-CreateCategoriesTable.ts
+++ b/src/database/migrations/1727220000000-CreateCategoriesTable.ts
@@ -1,0 +1,106 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCategoriesTable1727220000000 implements MigrationInterface {
+  name = 'CreateCategoriesTable1727220000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create categories table
+    await queryRunner.query(`
+      CREATE TABLE "categories" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "name" character varying(255) NOT NULL,
+        "description" text,
+        "slug" character varying(255) NOT NULL,
+        "parentId" uuid,
+        "isActive" boolean NOT NULL DEFAULT true,
+        "sortOrder" integer NOT NULL DEFAULT 0,
+        "metadata" jsonb,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now(),
+        "deletedAt" timestamptz,
+        CONSTRAINT "PK_categories" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_categories_slug" UNIQUE ("slug"),
+        CONSTRAINT "FK_categories_parent" FOREIGN KEY ("parentId") 
+          REFERENCES "categories"("id") ON DELETE CASCADE
+      )
+    `);
+
+    // Create indexes for better performance
+    await queryRunner.query(`
+      CREATE INDEX "IDX_categories_name" ON "categories" ("name")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_categories_parentId" ON "categories" ("parentId")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_categories_isActive" ON "categories" ("isActive")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_categories_sortOrder" ON "categories" ("sortOrder")
+    `);
+
+    // Composite index for hierarchical queries
+    await queryRunner.query(`
+      CREATE INDEX "IDX_categories_parent_active" ON "categories" ("parentId", "isActive")
+    `);
+
+    // Composite index for sorting within same level
+    await queryRunner.query(`
+      CREATE INDEX "IDX_categories_sort_name" ON "categories" ("sortOrder", "name")
+    `);
+
+    // Index for soft delete queries
+    await queryRunner.query(`
+      CREATE INDEX "IDX_categories_deletedAt" ON "categories" ("deletedAt")
+    `);
+
+    // Create trigger to auto-update updatedAt timestamp
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION update_categories_updated_at()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        NEW."updatedAt" = NOW();
+        RETURN NEW;
+      END;
+      $$ language 'plpgsql'
+    `);
+
+    await queryRunner.query(`
+      CREATE TRIGGER update_categories_updated_at 
+      BEFORE UPDATE ON "categories" 
+      FOR EACH ROW 
+      EXECUTE FUNCTION update_categories_updated_at()
+    `);
+
+    // Add some initial seed data for common categories
+    await queryRunner.query(`
+      INSERT INTO "categories" ("name", "slug", "description", "sortOrder", "isActive") VALUES
+      ('Electronics', 'electronics', 'Electronic products and gadgets', 10, true),
+      ('Clothing', 'clothing', 'Fashion and apparel', 20, true),
+      ('Home & Garden', 'home-garden', 'Home improvement and garden supplies', 30, true),
+      ('Books', 'books', 'Books and educational materials', 40, true),
+      ('Sports', 'sports', 'Sports and outdoor activities', 50, true);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop trigger and function
+    await queryRunner.query(`DROP TRIGGER IF EXISTS update_categories_updated_at ON "categories"`);
+    await queryRunner.query(`DROP FUNCTION IF EXISTS update_categories_updated_at()`);
+
+    // Drop indexes
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_categories_deletedAt"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_categories_sort_name"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_categories_parent_active"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_categories_sortOrder"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_categories_isActive"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_categories_parentId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_categories_name"`);
+
+    // Drop table (this will also drop the foreign key constraint)
+    await queryRunner.query(`DROP TABLE IF EXISTS "categories"`);
+  }
+}

--- a/src/database/migrations/1727221000000-AddCategoryToProducts.ts
+++ b/src/database/migrations/1727221000000-AddCategoryToProducts.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCategoryToProducts1727221000000 implements MigrationInterface {
+  name = 'AddCategoryToProducts1727221000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add category_id column to products table
+    await queryRunner.query(`
+      ALTER TABLE "products" 
+      ADD COLUMN "category_id" uuid;
+    `);
+
+    // Add foreign key constraint
+    await queryRunner.query(`
+      ALTER TABLE "products" 
+      ADD CONSTRAINT "FK_products_category" 
+      FOREIGN KEY ("category_id") 
+      REFERENCES "categories"("id") 
+      ON DELETE SET NULL;
+    `);
+
+    // Add index for better query performance
+    await queryRunner.query(`
+      CREATE INDEX "IDX_products_category_id" 
+      ON "products" ("category_id");
+    `);
+
+    // Add composite index for category-based product queries
+    await queryRunner.query(`
+      CREATE INDEX "IDX_products_category_active" 
+      ON "products" ("category_id", "is_active");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_products_category_active"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_products_category_id"`);
+
+    // Drop foreign key constraint
+    await queryRunner.query(
+      `ALTER TABLE "products" DROP CONSTRAINT IF EXISTS "FK_products_category"`,
+    );
+
+    // Drop column
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN IF EXISTS "category_id"`);
+  }
+}

--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -1,0 +1,360 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  Put,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  ParseUUIDPipe,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiForbiddenResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CategoriesService } from './categories.service';
+import {
+  CreateCategoryDto,
+  UpdateCategoryDto,
+  CategoryResponseDto,
+  CategoryTreeDto,
+  CategoryQueryDto,
+  PaginatedCategoriesResponseDto,
+} from './dto';
+
+@ApiTags('Categories')
+@Controller('categories')
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new category',
+    description: 'Creates a new category. Only admin users can create categories.',
+  })
+  @ApiBody({
+    type: CreateCategoryDto,
+    description: 'Category data',
+    examples: {
+      rootCategory: {
+        summary: 'Root category example',
+        value: {
+          name: 'Electronics',
+          description: 'Electronic products and gadgets',
+          slug: 'electronics',
+          sortOrder: 10,
+          metadata: {
+            color: '#FF5722',
+            icon: 'electronics-icon',
+          },
+        },
+      },
+      subCategory: {
+        summary: 'Sub-category example',
+        value: {
+          name: 'Smartphones',
+          description: 'Mobile phones and accessories',
+          parentId: '550e8400-e29b-41d4-a716-446655440000',
+          sortOrder: 5,
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Category created successfully',
+    type: CategoryResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized - JWT token required' })
+  @ApiForbiddenResponse({ description: 'Forbidden - Admin access required' })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  @ApiConflictResponse({ description: 'Category with this slug or name already exists' })
+  async create(@Body() createCategoryDto: CreateCategoryDto): Promise<CategoryResponseDto> {
+    return this.categoriesService.create(createCategoryDto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get all categories',
+    description: 'Retrieves a paginated list of categories with optional filtering and sorting.',
+  })
+  @ApiQuery({ type: CategoryQueryDto })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Categories retrieved successfully',
+    type: PaginatedCategoriesResponseDto,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid query parameters' })
+  async findAll(@Query() query: CategoryQueryDto): Promise<PaginatedCategoriesResponseDto> {
+    return this.categoriesService.findAll(query);
+  }
+
+  @Get('tree')
+  @ApiOperation({
+    summary: 'Get category tree',
+    description: 'Retrieves the complete category hierarchy as a tree structure.',
+  })
+  @ApiQuery({
+    name: 'includeInactive',
+    required: false,
+    type: Boolean,
+    description: 'Include inactive categories in the tree',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Category tree retrieved successfully',
+    type: [CategoryTreeDto],
+  })
+  @ApiBadRequestResponse({ description: 'Failed to build category tree' })
+  async getCategoryTree(
+    @Query('includeInactive') includeInactive?: string | boolean,
+  ): Promise<CategoryTreeDto[]> {
+    const includeInactiveBoolean = includeInactive === true || includeInactive === 'true';
+    return this.categoriesService.buildCategoryTree(includeInactiveBoolean);
+  }
+
+  @Get('slug/:slug')
+  @ApiOperation({
+    summary: 'Get category by slug',
+    description: 'Retrieves a category by its URL-friendly slug.',
+  })
+  @ApiParam({
+    name: 'slug',
+    description: 'Category slug',
+    example: 'electronics',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Category found',
+    type: CategoryResponseDto,
+  })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  async findBySlug(@Param('slug') slug: string): Promise<CategoryResponseDto> {
+    const category = await this.categoriesService.findBySlug(slug);
+    if (!category) {
+      throw new NotFoundException(`Category with slug '${slug}' not found`);
+    }
+    return category;
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get category by ID',
+    description: 'Retrieves a specific category by its unique identifier.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Category found',
+    type: CategoryResponseDto,
+  })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiBadRequestResponse({ description: 'Invalid UUID format' })
+  async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<CategoryResponseDto> {
+    return this.categoriesService.findOne(id);
+  }
+
+  @Get(':id/descendants')
+  @ApiOperation({
+    summary: 'Get category descendants',
+    description: 'Retrieves all descendant categories of a specific category.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiQuery({
+    name: 'maxDepth',
+    required: false,
+    type: Number,
+    description: 'Maximum depth to retrieve (unlimited if not specified)',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Descendants retrieved successfully',
+    type: [CategoryResponseDto],
+  })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiBadRequestResponse({ description: 'Invalid UUID format or maxDepth' })
+  async getDescendants(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('maxDepth') maxDepth?: number,
+  ): Promise<CategoryResponseDto[]> {
+    return this.categoriesService.getDescendants(id, maxDepth);
+  }
+
+  @Get(':id/path')
+  @ApiOperation({
+    summary: 'Get category path',
+    description: 'Retrieves the complete path from root to the specified category.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Category path retrieved successfully',
+    schema: {
+      type: 'array',
+      items: { type: 'string' },
+      example: ['Electronics', 'Computers', 'Laptops'],
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiBadRequestResponse({ description: 'Invalid UUID format' })
+  async getCategoryPath(@Param('id', ParseUUIDPipe) id: string): Promise<string[]> {
+    return this.categoriesService.getCategoryPath(id);
+  }
+
+  @Put(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Update category',
+    description: 'Updates a category. Only admin users can update categories.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiBody({
+    type: UpdateCategoryDto,
+    description: 'Updated category data',
+    examples: {
+      updateBasic: {
+        summary: 'Update basic info',
+        value: {
+          name: 'Consumer Electronics',
+          description: 'Updated description for consumer electronics',
+          sortOrder: 15,
+        },
+      },
+      moveCategory: {
+        summary: 'Move to different parent',
+        value: {
+          parentId: '550e8400-e29b-41d4-a716-446655440001',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Category updated successfully',
+    type: CategoryResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized - JWT token required' })
+  @ApiForbiddenResponse({ description: 'Forbidden - Admin access required' })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiBadRequestResponse({ description: 'Invalid input data or circular hierarchy' })
+  @ApiConflictResponse({ description: 'Category with this slug or name already exists' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateCategoryDto: UpdateCategoryDto,
+  ): Promise<CategoryResponseDto> {
+    return this.categoriesService.update(id, updateCategoryDto);
+  }
+
+  @Patch(':id/activate')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Activate category',
+    description: 'Activates a category. Only admin users can activate categories.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Category activated successfully',
+    type: CategoryResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized - JWT token required' })
+  @ApiForbiddenResponse({ description: 'Forbidden - Admin access required' })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiBadRequestResponse({ description: 'Failed to activate category' })
+  async activate(@Param('id', ParseUUIDPipe) id: string): Promise<CategoryResponseDto> {
+    return this.categoriesService.activate(id);
+  }
+
+  @Patch(':id/deactivate')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Deactivate category',
+    description: 'Deactivates a category. Only admin users can deactivate categories.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Category deactivated successfully',
+    type: CategoryResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized - JWT token required' })
+  @ApiForbiddenResponse({ description: 'Forbidden - Admin access required' })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiBadRequestResponse({ description: 'Failed to deactivate category' })
+  async deactivate(@Param('id', ParseUUIDPipe) id: string): Promise<CategoryResponseDto> {
+    return this.categoriesService.deactivate(id);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete category',
+    description:
+      'Soft deletes a category. Only admin users can delete categories. Categories with children or products cannot be deleted.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Category deleted successfully',
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized - JWT token required' })
+  @ApiForbiddenResponse({ description: 'Forbidden - Admin access required' })
+  @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiBadRequestResponse({ description: 'Cannot delete category with children or products' })
+  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.categoriesService.remove(id);
+  }
+}

--- a/src/modules/categories/categories.module.ts
+++ b/src/modules/categories/categories.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CategoriesService } from './categories.service';
+import { CategoriesController } from './categories.controller';
+import { Category } from './entities/category.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Category])],
+  controllers: [CategoriesController],
+  providers: [CategoriesService],
+  exports: [CategoriesService, TypeOrmModule],
+})
+export class CategoriesModule {}

--- a/src/modules/categories/categories.service.ts
+++ b/src/modules/categories/categories.service.ts
@@ -1,0 +1,651 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder, IsNull } from 'typeorm';
+import { plainToInstance } from 'class-transformer';
+import { Category } from './entities/category.entity';
+import {
+  CreateCategoryDto,
+  UpdateCategoryDto,
+  CategoryResponseDto,
+  CategoryTreeDto,
+  CategoryQueryDto,
+  PaginatedCategoriesResponseDto,
+} from './dto';
+
+@Injectable()
+export class CategoriesService {
+  private readonly logger = new Logger(CategoriesService.name);
+
+  constructor(
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+  ) {}
+
+  async create(createCategoryDto: CreateCategoryDto): Promise<CategoryResponseDto> {
+    try {
+      // Generate slug if not provided
+      let slug = createCategoryDto.slug;
+      if (!slug) {
+        slug = this.generateSlug(createCategoryDto.name);
+      }
+
+      // Check for unique slug
+      const existingBySlug = await this.findBySlug(slug);
+      if (existingBySlug) {
+        throw new ConflictException(`Category with slug '${slug}' already exists`);
+      }
+
+      // Validate parent category if provided
+      if (createCategoryDto.parentId) {
+        const foundParent = await this.findById(createCategoryDto.parentId, {
+          includeInactive: true,
+        });
+        if (!foundParent) {
+          throw new BadRequestException(
+            `Parent category with ID ${createCategoryDto.parentId} not found`,
+          );
+        }
+      }
+
+      // Check for unique name within the same level (same parent)
+      await this.validateUniqueNameInLevel(createCategoryDto.name, createCategoryDto.parentId);
+
+      // Create the category
+      const category = this.categoryRepository.create({
+        ...createCategoryDto,
+        slug,
+      });
+
+      const savedCategory = await this.categoryRepository.save(category);
+
+      this.logger.log(
+        `Category created successfully: ${savedCategory.name} (ID: ${savedCategory.id})`,
+      );
+
+      return await this.findOne(savedCategory.id);
+    } catch (error) {
+      if (error instanceof ConflictException || error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error(
+        `Failed to create category: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw new BadRequestException('Failed to create category');
+    }
+  }
+
+  async findAll(queryDto: CategoryQueryDto): Promise<PaginatedCategoriesResponseDto> {
+    try {
+      const {
+        page = 1,
+        limit = 10,
+        search,
+        parentId,
+        isActive,
+        includeInactive = false,
+        includeDeleted = false,
+        sortBy = 'sortOrder',
+        sortOrder = 'ASC',
+        includeProductCount = false,
+        maxDepth = 0,
+      } = queryDto;
+
+      const queryBuilder = this.createBaseQuery({ includeDeleted });
+
+      // Apply filters
+      this.applyFilters(queryBuilder, {
+        search,
+        parentId,
+        isActive,
+        includeInactive,
+      });
+
+      // Apply sorting
+      this.applySorting(queryBuilder, sortBy, sortOrder);
+
+      // Get total count before pagination
+      const total = await queryBuilder.getCount();
+
+      // Apply pagination
+      const offset = (page - 1) * limit;
+      queryBuilder.skip(offset).take(limit);
+
+      // Execute query
+      const categories = await queryBuilder.getMany();
+
+      // Build hierarchical structure if maxDepth > 0
+      let processedCategories = categories;
+      if (maxDepth > 0) {
+        processedCategories = await this.buildHierarchyForCategories(categories, maxDepth);
+      }
+
+      // Add product count if requested
+      if (includeProductCount) {
+        // TODO: Implement product count when Product entity is integrated
+        processedCategories.forEach((category) => {
+          category.productCount = 0; // Placeholder
+        });
+      }
+
+      // Transform to response DTOs
+      const data = plainToInstance(CategoryResponseDto, processedCategories, {
+        excludeExtraneousValues: true,
+      });
+
+      // Calculate pagination metadata
+      const totalPages = Math.ceil(total / limit);
+      const hasNext = page < totalPages;
+      const hasPrev = page > 1;
+
+      return {
+        data,
+        meta: {
+          total,
+          page,
+          limit,
+          totalPages,
+          hasNext,
+          hasPrev,
+        },
+      };
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch categories: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw new BadRequestException('Failed to fetch categories');
+    }
+  }
+
+  async findOne(id: string): Promise<CategoryResponseDto> {
+    const category = await this.findById(id, { includeRelations: true });
+    if (!category) {
+      throw new NotFoundException(`Category with ID ${id} not found`);
+    }
+
+    // Add computed properties
+    category.level = category.getLevel();
+    category.path = category.getPath();
+
+    return plainToInstance(CategoryResponseDto, category, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  async findBySlug(slug: string): Promise<CategoryResponseDto | null> {
+    const category = await this.categoryRepository.findOne({
+      where: { slug, deletedAt: IsNull() },
+      relations: ['parent', 'children'],
+    });
+
+    if (!category) {
+      return null;
+    }
+
+    // Add computed properties
+    category.level = category.getLevel();
+    category.path = category.getPath();
+
+    return plainToInstance(CategoryResponseDto, category, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  async buildCategoryTree(includeInactive = false): Promise<CategoryTreeDto[]> {
+    try {
+      this.logger.debug(`Building category tree, includeInactive: ${includeInactive}`);
+
+      const queryBuilder = this.categoryRepository
+        .createQueryBuilder('category')
+        .where('category.deletedAt IS NULL')
+        .orderBy('category.sortOrder', 'ASC')
+        .addOrderBy('category.name', 'ASC');
+
+      if (!includeInactive) {
+        queryBuilder.andWhere('category.isActive = :isActive', { isActive: true });
+      }
+
+      const categories = await queryBuilder.getMany();
+
+      this.logger.debug(`Found ${categories.length} categories to build tree`);
+
+      if (categories.length === 0) {
+        return [];
+      }
+
+      const tree = this.buildTreeStructure(categories);
+
+      this.logger.debug(`Built tree with ${tree.length} root categories`);
+
+      return tree;
+    } catch (error) {
+      this.logger.error(
+        `Failed to build category tree: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      throw new BadRequestException('Failed to build category tree');
+    }
+  }
+
+  async update(id: string, updateCategoryDto: UpdateCategoryDto): Promise<CategoryResponseDto> {
+    try {
+      const category = await this.findById(id, { includeInactive: true });
+      if (!category) {
+        throw new NotFoundException(`Category with ID ${id} not found`);
+      }
+
+      // Validate hierarchy to prevent cycles
+      if (updateCategoryDto.parentId) {
+        await this.validateHierarchy(updateCategoryDto.parentId, id);
+      }
+
+      // Check for unique slug if being updated
+      if (updateCategoryDto.slug && updateCategoryDto.slug !== category.slug) {
+        const existingBySlug = await this.findBySlug(updateCategoryDto.slug);
+        if (existingBySlug && existingBySlug.id !== id) {
+          throw new ConflictException(
+            `Category with slug '${updateCategoryDto.slug}' already exists`,
+          );
+        }
+      }
+
+      // Check for unique name within the same level if name or parent is being updated
+      if (updateCategoryDto.name || updateCategoryDto.parentId) {
+        const name = updateCategoryDto.name || category.name;
+        const parentId =
+          updateCategoryDto.parentId !== undefined ? updateCategoryDto.parentId : category.parentId;
+        await this.validateUniqueNameInLevel(name, parentId, id);
+      }
+
+      // Update the category using merge and save to handle JSONB properly
+      this.categoryRepository.merge(category, updateCategoryDto);
+      await this.categoryRepository.save(category);
+      this.logger.log(`Category updated successfully: ${category.name} (ID: ${id})`);
+
+      return await this.findOne(id);
+    } catch (error) {
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ConflictException ||
+        error instanceof BadRequestException
+      ) {
+        throw error;
+      }
+      this.logger.error(
+        `Failed to update category ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw new BadRequestException('Failed to update category');
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      // Check if category exists first without relations
+      const category = await this.findById(id, { includeInactive: true });
+      if (!category) {
+        throw new NotFoundException(`Category with ID ${id} not found`);
+      }
+
+      // Check if category has active children (not soft-deleted)
+      const childrenCount = await this.categoryRepository.count({
+        where: {
+          parentId: id,
+          deletedAt: IsNull(),
+        },
+      });
+
+      if (childrenCount > 0) {
+        throw new BadRequestException(
+          'Cannot delete category that has child categories. Delete children first.',
+        );
+      }
+
+      // TODO: Check if category has products when Product entity is integrated
+      // const productCount = await this.getProductCount(id);
+      // if (productCount > 0) {
+      //   throw new BadRequestException('Cannot delete category that contains products. Move products first.');
+      // }
+
+      // Soft delete the category
+      await this.categoryRepository.softDelete(id);
+
+      this.logger.log(`Category soft deleted: ${category.name} (ID: ${id})`);
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error(
+        `Failed to delete category ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw new BadRequestException('Failed to delete category');
+    }
+  }
+
+  async activate(id: string): Promise<CategoryResponseDto> {
+    return this.updateStatus(id, true);
+  }
+
+  async deactivate(id: string): Promise<CategoryResponseDto> {
+    return this.updateStatus(id, false);
+  }
+
+  // Utility functions
+  async getCategoryPath(categoryId: string): Promise<string[]> {
+    const category = await this.findById(categoryId, { includeRelations: true });
+    if (!category) {
+      throw new NotFoundException(`Category with ID ${categoryId} not found`);
+    }
+    return category.getPath();
+  }
+
+  async getDescendants(categoryId: string, maxDepth?: number): Promise<CategoryResponseDto[]> {
+    const category = await this.findById(categoryId);
+    if (!category) {
+      throw new NotFoundException(`Category with ID ${categoryId} not found`);
+    }
+
+    const descendants = await this.findDescendants(categoryId, maxDepth);
+    return plainToInstance(CategoryResponseDto, descendants, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  async validateHierarchy(parentId: string, childId: string): Promise<void> {
+    if (parentId === childId) {
+      throw new BadRequestException('Category cannot be its own parent');
+    }
+
+    const parentCategory = await this.findById(parentId, { includeInactive: true });
+    if (!parentCategory) {
+      throw new BadRequestException(`Parent category with ID ${parentId} not found`);
+    }
+
+    const childCategory = await this.findById(childId, { includeInactive: true });
+    if (!childCategory) {
+      throw new BadRequestException(`Child category with ID ${childId} not found`);
+    }
+
+    // Check if parentCategory is a descendant of childCategory by traversing the hierarchy
+    const descendants = await this.getDescendants(childId);
+    const descendantIds = descendants.map((d) => d.id);
+
+    if (descendantIds.includes(parentId)) {
+      throw new BadRequestException(
+        'Cannot create circular hierarchy: parent cannot be a descendant of child',
+      );
+    }
+  }
+
+  generateSlug(name: string): string {
+    return name
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '') // Remove special characters
+      .replace(/[\s_-]+/g, '-') // Replace spaces, underscores, and hyphens with single hyphen
+      .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
+  }
+
+  // Private helper methods
+  private async findById(
+    id: string,
+    options: {
+      includeInactive?: boolean;
+      includeDeleted?: boolean;
+      includeRelations?: boolean;
+    } = {},
+  ): Promise<Category | null> {
+    const queryBuilder = this.categoryRepository.createQueryBuilder('category');
+    queryBuilder.where('category.id = :id', { id });
+
+    if (options.includeRelations) {
+      queryBuilder
+        .leftJoinAndSelect('category.parent', 'parent')
+        .leftJoinAndSelect('category.children', 'children');
+    }
+
+    if (!options.includeDeleted) {
+      queryBuilder.andWhere('category.deletedAt IS NULL');
+    }
+
+    if (!options.includeInactive) {
+      queryBuilder.andWhere('category.isActive = :isActive', { isActive: true });
+    }
+
+    return await queryBuilder.getOne();
+  }
+
+  private createBaseQuery(
+    options: { includeDeleted?: boolean } = {},
+  ): SelectQueryBuilder<Category> {
+    const queryBuilder = this.categoryRepository.createQueryBuilder('category');
+
+    if (!options.includeDeleted) {
+      queryBuilder.where('category.deletedAt IS NULL');
+    }
+
+    return queryBuilder;
+  }
+
+  private applyFilters(
+    queryBuilder: SelectQueryBuilder<Category>,
+    filters: {
+      search?: string;
+      parentId?: string;
+      isActive?: boolean;
+      includeInactive?: boolean;
+    },
+  ): void {
+    const { search, parentId, isActive, includeInactive } = filters;
+
+    // Search filter
+    if (search) {
+      queryBuilder.andWhere('(category.name ILIKE :search OR category.description ILIKE :search)', {
+        search: `%${search}%`,
+      });
+    }
+
+    // Parent filter
+    if (parentId !== undefined) {
+      if (parentId) {
+        queryBuilder.andWhere('category.parentId = :parentId', { parentId });
+      } else {
+        queryBuilder.andWhere('category.parentId IS NULL');
+      }
+    }
+
+    // Active status filter
+    if (!includeInactive && isActive !== undefined) {
+      queryBuilder.andWhere('category.isActive = :isActive', { isActive });
+    } else if (!includeInactive) {
+      queryBuilder.andWhere('category.isActive = :isActive', { isActive: true });
+    }
+  }
+
+  private applySorting(
+    queryBuilder: SelectQueryBuilder<Category>,
+    sortBy: string,
+    sortOrder: 'ASC' | 'DESC',
+  ): void {
+    const validSortFields = ['name', 'createdAt', 'updatedAt', 'sortOrder'];
+    const field = validSortFields.includes(sortBy) ? sortBy : 'sortOrder';
+
+    queryBuilder.orderBy(`category.${field}`, sortOrder);
+
+    // Always add secondary sort for consistency
+    if (field !== 'name') {
+      queryBuilder.addOrderBy('category.name', 'ASC');
+    }
+    queryBuilder.addOrderBy('category.id', 'ASC');
+  }
+
+  private async validateUniqueNameInLevel(
+    name: string,
+    parentId?: string,
+    excludeId?: string,
+  ): Promise<void> {
+    const queryBuilder = this.categoryRepository
+      .createQueryBuilder('category')
+      .where('category.name = :name', { name })
+      .andWhere('category.deletedAt IS NULL');
+
+    if (parentId) {
+      queryBuilder.andWhere('category.parentId = :parentId', { parentId });
+    } else {
+      queryBuilder.andWhere('category.parentId IS NULL');
+    }
+
+    if (excludeId) {
+      queryBuilder.andWhere('category.id != :excludeId', { excludeId });
+    }
+
+    const existing = await queryBuilder.getOne();
+    if (existing) {
+      const levelDescription = parentId ? `under the same parent` : `at the root level`;
+      throw new ConflictException(
+        `Category with name '${name}' already exists ${levelDescription}`,
+      );
+    }
+  }
+
+  private async updateStatus(id: string, isActive: boolean): Promise<CategoryResponseDto> {
+    try {
+      const category = await this.findById(id, { includeInactive: true });
+      if (!category) {
+        throw new NotFoundException(`Category with ID ${id} not found`);
+      }
+
+      await this.categoryRepository.update(id, { isActive });
+
+      const action = isActive ? 'activated' : 'deactivated';
+      this.logger.log(`Category ${action}: ${category.name} (ID: ${id})`);
+
+      // Get the updated category with proper options
+      return await this.findById(id, { includeRelations: true, includeInactive: true }).then(
+        (updatedCategory) => {
+          if (!updatedCategory) {
+            throw new NotFoundException(`Category with ID ${id} not found after update`);
+          }
+
+          // Add computed properties
+          updatedCategory.level = updatedCategory.getLevel();
+          updatedCategory.path = updatedCategory.getPath();
+
+          return plainToInstance(CategoryResponseDto, updatedCategory, {
+            excludeExtraneousValues: true,
+          });
+        },
+      );
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error(
+        `Failed to update category status ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw new BadRequestException('Failed to update category status');
+    }
+  }
+
+  private async buildHierarchyForCategories(
+    categories: Category[],
+    _maxDepth: number,
+  ): Promise<Category[]> {
+    const categoryMap = new Map<string, Category>();
+    const rootCategories: Category[] = [];
+
+    // Create a map for quick lookup
+    categories.forEach((category) => {
+      categoryMap.set(category.id, category);
+      category.children = [];
+      if (!category.parentId) {
+        rootCategories.push(category);
+      }
+    });
+
+    // Build hierarchy
+    categories.forEach((category) => {
+      if (category.parentId && categoryMap.has(category.parentId)) {
+        const parent = categoryMap.get(category.parentId)!;
+        if (!parent.children) {
+          parent.children = [];
+        }
+        parent.children.push(category);
+      }
+    });
+
+    return rootCategories;
+  }
+
+  private buildTreeStructure(
+    categories: Category[],
+    parentId?: string,
+    currentDepth = 0,
+  ): CategoryTreeDto[] {
+    // Protection against infinite recursion
+    if (currentDepth > 10) {
+      this.logger.warn(`Maximum depth reached (${currentDepth}) for parentId: ${parentId}`);
+      return [];
+    }
+
+    const tree: CategoryTreeDto[] = [];
+
+    const filteredCategories = categories.filter((cat) => {
+      // Ensure we're comparing the right values
+      if (parentId === undefined) {
+        return cat.parentId === null || cat.parentId === undefined;
+      }
+      return cat.parentId === parentId;
+    });
+
+    filteredCategories
+      .sort((a, b) => {
+        if (a.sortOrder !== b.sortOrder) {
+          return a.sortOrder - b.sortOrder;
+        }
+        return a.name.localeCompare(b.name);
+      })
+      .forEach((category) => {
+        const treeNode = plainToInstance(CategoryTreeDto, category, {
+          excludeExtraneousValues: true,
+        });
+
+        treeNode.level = currentDepth;
+        treeNode.children = this.buildTreeStructure(categories, category.id, currentDepth + 1);
+        treeNode.hasChildren = treeNode.children.length > 0;
+
+        tree.push(treeNode);
+      });
+
+    return tree;
+  }
+
+  private async findDescendants(categoryId: string, maxDepth?: number): Promise<Category[]> {
+    // Build a recursive query to find all descendants
+    let currentParentIds = [categoryId];
+    const allDescendants: Category[] = [];
+    let depth = 0;
+
+    while (currentParentIds.length > 0 && (!maxDepth || depth < maxDepth)) {
+      const descendants = await this.categoryRepository
+        .createQueryBuilder('category')
+        .where('category.parentId IN (:...parentIds)', { parentIds: currentParentIds })
+        .andWhere('category.deletedAt IS NULL')
+        .getMany();
+
+      if (descendants.length === 0) {
+        break;
+      }
+
+      allDescendants.push(...descendants);
+      currentParentIds = descendants.map((d) => d.id);
+      depth++;
+    }
+
+    return allDescendants;
+  }
+}

--- a/src/modules/categories/dto/category-query.dto.ts
+++ b/src/modules/categories/dto/category-query.dto.ts
@@ -1,0 +1,144 @@
+import { IsOptional, IsBoolean, IsUUID, IsString, IsInt, Min, Max, IsIn } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+
+export class CategoryQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number for pagination',
+    example: 1,
+    minimum: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'Page must be an integer' })
+  @Min(1, { message: 'Page must be at least 1' })
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    example: 10,
+    minimum: 1,
+    maximum: 100,
+    default: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'Limit must be an integer' })
+  @Min(1, { message: 'Limit must be at least 1' })
+  @Max(100, { message: 'Limit must not exceed 100' })
+  limit?: number = 10;
+
+  @ApiPropertyOptional({
+    description: 'Search term for category name and description',
+    example: 'electronics',
+  })
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => value?.trim())
+  search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by parent category ID (null for root categories)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsUUID(4, { message: 'Parent ID must be a valid UUID' })
+  parentId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by active status',
+    example: true,
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return undefined;
+  })
+  @IsBoolean()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Include inactive categories in results',
+    example: false,
+    default: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return false;
+  })
+  @IsBoolean()
+  includeInactive?: boolean = false;
+
+  @ApiPropertyOptional({
+    description: 'Include deleted categories in results (admin only)',
+    example: false,
+    default: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return false;
+  })
+  @IsBoolean()
+  includeDeleted?: boolean = false;
+
+  @ApiPropertyOptional({
+    description: 'Sort field',
+    example: 'sortOrder',
+    enum: ['name', 'createdAt', 'updatedAt', 'sortOrder'],
+    default: 'sortOrder',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['name', 'createdAt', 'updatedAt', 'sortOrder'], {
+    message: 'Sort by must be one of: name, createdAt, updatedAt, sortOrder',
+  })
+  sortBy?: string = 'sortOrder';
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    example: 'ASC',
+    enum: ['ASC', 'DESC'],
+    default: 'ASC',
+  })
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => value?.toUpperCase())
+  @IsIn(['ASC', 'DESC'], {
+    message: 'Sort order must be ASC or DESC',
+  })
+  sortOrder?: 'ASC' | 'DESC' = 'ASC';
+
+  @ApiPropertyOptional({
+    description: 'Include product count for each category',
+    example: false,
+    default: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return false;
+  })
+  @IsBoolean()
+  includeProductCount?: boolean = false;
+
+  @ApiPropertyOptional({
+    description: 'Maximum depth for hierarchical queries (0 for flat list)',
+    example: 2,
+    minimum: 0,
+    maximum: 10,
+    default: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'Max depth must be an integer' })
+  @Min(0, { message: 'Max depth must be non-negative' })
+  @Max(10, { message: 'Max depth must not exceed 10' })
+  maxDepth?: number = 0;
+}

--- a/src/modules/categories/dto/category-response.dto.ts
+++ b/src/modules/categories/dto/category-response.dto.ts
@@ -1,0 +1,127 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose, Transform, Type } from 'class-transformer';
+
+export class CategoryResponseDto {
+  @ApiProperty({
+    description: 'Category unique identifier',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @Expose()
+  id: string;
+
+  @ApiProperty({
+    description: 'Category name',
+    example: 'Electronics',
+  })
+  @Expose()
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Category description',
+    example: 'Electronic products and gadgets',
+  })
+  @Expose()
+  description?: string;
+
+  @ApiProperty({
+    description: 'URL-friendly slug for SEO',
+    example: 'electronics',
+  })
+  @Expose()
+  slug: string;
+
+  @ApiPropertyOptional({
+    description: 'Parent category ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @Expose()
+  parentId?: string;
+
+  @ApiProperty({
+    description: 'Whether the category is active',
+    example: true,
+  })
+  @Expose()
+  isActive: boolean;
+
+  @ApiProperty({
+    description: 'Sort order for category ordering',
+    example: 10,
+  })
+  @Expose()
+  sortOrder: number;
+
+  @ApiPropertyOptional({
+    description: 'Additional metadata for the category',
+    example: {
+      color: '#FF5722',
+      icon: 'electronics-icon',
+    },
+  })
+  @Expose()
+  metadata?: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Category creation timestamp',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  @Expose()
+  createdAt: Date;
+
+  @ApiProperty({
+    description: 'Category last update timestamp',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  @Expose()
+  updatedAt: Date;
+
+  @ApiPropertyOptional({
+    description: 'Parent category information',
+  })
+  @Expose()
+  @Type(() => CategoryResponseDto)
+  parent?: CategoryResponseDto;
+
+  @ApiPropertyOptional({
+    description: 'Child categories',
+    type: [CategoryResponseDto],
+  })
+  @Expose()
+  @Type(() => CategoryResponseDto)
+  children?: CategoryResponseDto[];
+
+  @ApiPropertyOptional({
+    description: 'Hierarchical level (0 for root categories)',
+    example: 1,
+  })
+  @Expose()
+  level?: number;
+
+  @ApiPropertyOptional({
+    description: 'Category path from root to current category',
+    example: ['Electronics', 'Computers'],
+    type: [String],
+  })
+  @Expose()
+  path?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Number of products in this category and subcategories',
+    example: 150,
+  })
+  @Expose()
+  productCount?: number;
+
+  @ApiPropertyOptional({
+    description: 'Breadcrumb path for navigation',
+    example: 'Electronics > Computers',
+  })
+  @Expose()
+  @Transform(({ obj }) => {
+    if (obj.path && Array.isArray(obj.path)) {
+      return obj.path.join(' > ');
+    }
+    return undefined;
+  })
+  breadcrumb?: string;
+}

--- a/src/modules/categories/dto/category-tree.dto.ts
+++ b/src/modules/categories/dto/category-tree.dto.ts
@@ -1,0 +1,98 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+
+export class CategoryTreeDto {
+  @ApiProperty({
+    description: 'Category unique identifier',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @Expose()
+  id: string;
+
+  @ApiProperty({
+    description: 'Category name',
+    example: 'Electronics',
+  })
+  @Expose()
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Category description',
+    example: 'Electronic products and gadgets',
+  })
+  @Expose()
+  description?: string;
+
+  @ApiProperty({
+    description: 'URL-friendly slug for SEO',
+    example: 'electronics',
+  })
+  @Expose()
+  slug: string;
+
+  @ApiPropertyOptional({
+    description: 'Parent category ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @Expose()
+  parentId?: string;
+
+  @ApiProperty({
+    description: 'Whether the category is active',
+    example: true,
+  })
+  @Expose()
+  isActive: boolean;
+
+  @ApiProperty({
+    description: 'Sort order for category ordering',
+    example: 10,
+  })
+  @Expose()
+  sortOrder: number;
+
+  @ApiPropertyOptional({
+    description: 'Additional metadata for the category',
+    example: {
+      color: '#FF5722',
+      icon: 'electronics-icon',
+    },
+  })
+  @Expose()
+  metadata?: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Hierarchical level (0 for root categories)',
+    example: 0,
+  })
+  @Expose()
+  level: number;
+
+  @ApiPropertyOptional({
+    description: 'Number of products in this category and subcategories',
+    example: 150,
+  })
+  @Expose()
+  productCount?: number;
+
+  @ApiProperty({
+    description: 'Child categories in tree structure',
+    type: [CategoryTreeDto],
+  })
+  @Expose()
+  @Type(() => CategoryTreeDto)
+  children: CategoryTreeDto[];
+
+  @ApiProperty({
+    description: 'Whether this category has children',
+    example: true,
+  })
+  @Expose()
+  hasChildren: boolean;
+
+  constructor() {
+    this.children = [];
+    this.level = 0;
+    this.hasChildren = false;
+  }
+}

--- a/src/modules/categories/dto/create-category.dto.ts
+++ b/src/modules/categories/dto/create-category.dto.ts
@@ -1,0 +1,85 @@
+import {
+  IsString,
+  IsOptional,
+  IsUUID,
+  IsInt,
+  IsObject,
+  MinLength,
+  MaxLength,
+  Matches,
+  Min,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+
+export class CreateCategoryDto {
+  @ApiProperty({
+    description: 'Category name',
+    example: 'Electronics',
+    minLength: 2,
+    maxLength: 255,
+  })
+  @IsString()
+  @MinLength(2, { message: 'Category name must be at least 2 characters long' })
+  @MaxLength(255, { message: 'Category name must not exceed 255 characters' })
+  @Transform(({ value }) => value?.trim())
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Category description',
+    example: 'Electronic products and gadgets',
+    maxLength: 1000,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000, { message: 'Description must not exceed 1000 characters' })
+  @Transform(({ value }) => value?.trim() || undefined)
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'URL-friendly slug for SEO. If not provided, it will be generated from name',
+    example: 'electronics',
+    pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+    message: 'Slug must contain only lowercase letters, numbers, and hyphens',
+  })
+  @MinLength(2, { message: 'Slug must be at least 2 characters long' })
+  @MaxLength(255, { message: 'Slug must not exceed 255 characters' })
+  @Transform(({ value }) => value?.toLowerCase().trim() || undefined)
+  slug?: string;
+
+  @ApiPropertyOptional({
+    description: 'Parent category ID for hierarchical structure',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsUUID(4, { message: 'Parent ID must be a valid UUID' })
+  parentId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Sort order for category ordering within same level',
+    example: 10,
+    minimum: 0,
+    default: 0,
+  })
+  @IsOptional()
+  @IsInt({ message: 'Sort order must be an integer' })
+  @Min(0, { message: 'Sort order must be non-negative' })
+  @Transform(({ value }) => (value !== undefined ? parseInt(value, 10) : 0))
+  sortOrder?: number;
+
+  @ApiPropertyOptional({
+    description: 'Additional metadata for the category',
+    example: {
+      color: '#FF5722',
+      icon: 'electronics-icon',
+      seoKeywords: ['electronics', 'gadgets', 'technology'],
+    },
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/modules/categories/dto/index.ts
+++ b/src/modules/categories/dto/index.ts
@@ -1,0 +1,6 @@
+export { CreateCategoryDto } from './create-category.dto';
+export { UpdateCategoryDto } from './update-category.dto';
+export { CategoryResponseDto } from './category-response.dto';
+export { CategoryTreeDto } from './category-tree.dto';
+export { CategoryQueryDto } from './category-query.dto';
+export { PaginatedCategoriesResponseDto } from './paginated-categories-response.dto';

--- a/src/modules/categories/dto/paginated-categories-response.dto.ts
+++ b/src/modules/categories/dto/paginated-categories-response.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+import { CategoryResponseDto } from './category-response.dto';
+
+class PaginationMetaDto {
+  @ApiProperty({ description: 'Total number of items', example: 100 })
+  @Expose()
+  total: number;
+
+  @ApiProperty({ description: 'Current page number', example: 1 })
+  @Expose()
+  page: number;
+
+  @ApiProperty({ description: 'Number of items per page', example: 10 })
+  @Expose()
+  limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 10 })
+  @Expose()
+  totalPages: number;
+
+  @ApiProperty({ description: 'Whether there is a next page', example: true })
+  @Expose()
+  hasNext: boolean;
+
+  @ApiProperty({ description: 'Whether there is a previous page', example: false })
+  @Expose()
+  hasPrev: boolean;
+}
+
+export class PaginatedCategoriesResponseDto {
+  @ApiProperty({
+    description: 'Array of categories',
+    type: [CategoryResponseDto],
+  })
+  @Expose()
+  @Type(() => CategoryResponseDto)
+  data: CategoryResponseDto[];
+
+  @ApiProperty({
+    description: 'Pagination metadata',
+    type: PaginationMetaDto,
+  })
+  @Expose()
+  @Type(() => PaginationMetaDto)
+  meta: PaginationMetaDto;
+}

--- a/src/modules/categories/dto/update-category.dto.ts
+++ b/src/modules/categories/dto/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/src/modules/categories/entities/category.entity.ts
+++ b/src/modules/categories/entities/category.entity.ts
@@ -1,0 +1,144 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  Index,
+  BeforeInsert,
+  BeforeUpdate,
+} from 'typeorm';
+import { Exclude } from 'class-transformer';
+import { Product } from '../../products/entities/product.entity';
+
+@Entity('categories')
+@Index(['parentId', 'isActive'])
+@Index(['slug'], { unique: true })
+@Index(['sortOrder', 'name'])
+export class Category {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  @Index()
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  @Index()
+  slug: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  @Index()
+  parentId?: string;
+
+  @Column({ type: 'boolean', default: true })
+  @Index()
+  isActive: boolean;
+
+  @Column({ type: 'integer', default: 0 })
+  @Index()
+  sortOrder: number;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata?: Record<string, unknown>;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date;
+
+  @DeleteDateColumn({ type: 'timestamp with time zone', nullable: true })
+  @Exclude()
+  deletedAt?: Date;
+
+  // Relations
+  @ManyToOne(() => Category, (category) => category.children, {
+    nullable: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'parentId' })
+  parent?: Category;
+
+  @OneToMany(() => Category, (category) => category.parent, {
+    cascade: true,
+  })
+  children?: Category[];
+
+  @OneToMany(() => Product, (product) => product.category)
+  products?: Product[];
+
+  // Virtual properties (not stored in DB)
+  level?: number;
+  path?: string[];
+  productCount?: number;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  generateSlugIfEmpty() {
+    if (!this.slug && this.name) {
+      this.slug = this.generateSlug(this.name);
+    }
+  }
+
+  private generateSlug(name: string): string {
+    return name
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '') // Remove special characters
+      .replace(/[\s_-]+/g, '-') // Replace spaces, underscores, and hyphens with single hyphen
+      .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
+  }
+
+  // Helper methods
+  isRoot(): boolean {
+    return !this.parentId;
+  }
+
+  hasChildren(): boolean {
+    return Boolean(this.children && this.children.length > 0);
+  }
+
+  isDescendantOf(category: Category): boolean {
+    let current = this.parent;
+    while (current) {
+      if (current.id === category.id) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  getAncestors(): Category[] {
+    const ancestors: Category[] = [];
+    let current = this.parent;
+    while (current) {
+      ancestors.unshift(current);
+      current = current.parent;
+    }
+    return ancestors;
+  }
+
+  getLevel(): number {
+    if (this.level !== undefined) {
+      return this.level;
+    }
+    return this.getAncestors().length;
+  }
+
+  getPath(): string[] {
+    if (this.path !== undefined) {
+      return this.path;
+    }
+    const ancestors = this.getAncestors();
+    return [...ancestors.map((a) => a.name), this.name];
+  }
+}

--- a/src/modules/categories/entities/index.ts
+++ b/src/modules/categories/entities/index.ts
@@ -1,0 +1,1 @@
+export { Category } from './category.entity';

--- a/src/modules/categories/index.ts
+++ b/src/modules/categories/index.ts
@@ -1,0 +1,5 @@
+export { CategoriesModule } from './categories.module';
+export { CategoriesService } from './categories.service';
+export { CategoriesController } from './categories.controller';
+export * from './entities';
+export * from './dto';

--- a/src/modules/products/entities/product.entity.ts
+++ b/src/modules/products/entities/product.entity.ts
@@ -10,9 +10,12 @@ import {
   BeforeUpdate,
   OneToMany,
   OneToOne,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
 import { OrderItem } from '../../orders/entities/order-item.entity';
 import { Inventory } from '../../inventory/entities/inventory.entity';
+import { Category } from '../../categories/entities/category.entity';
 
 @Entity('products')
 @Index('idx_products_sku', ['sku'], { unique: true })
@@ -140,6 +143,14 @@ export class Product {
   })
   minimumStock!: number;
 
+  @Column({
+    type: 'uuid',
+    nullable: true,
+    name: 'category_id',
+    comment: 'Reference to product category',
+  })
+  categoryId?: string;
+
   @CreateDateColumn({
     type: 'timestamptz',
     name: 'created_at',
@@ -165,6 +176,10 @@ export class Product {
 
   @OneToOne(() => Inventory, (inventory) => inventory.product, { lazy: true })
   inventory!: Promise<Inventory>;
+
+  @ManyToOne(() => Category, (category) => category.products, { nullable: true })
+  @JoinColumn({ name: 'category_id' })
+  category?: Category;
 
   // Virtual Properties
   get isOnSale(): boolean {


### PR DESCRIPTION
This pull request introduces a comprehensive category management system to the application. It adds a new `categories` module with controller, service, and entity, establishes the database schema for categories (including support for hierarchical categories and soft deletes), and links products to categories. The changes also provide robust API endpoints for category CRUD operations, tree queries, and advanced filtering, complete with validation and documentation.

**Database Schema & Relations**
- Added a migration to create the `categories` table with support for hierarchy (parent-child), soft deletes, metadata, and several indexes for query performance. Also includes a trigger for automatic `updatedAt` timestamp updates and initial seed data for common categories.
- Added a migration to link products to categories via a new `category_id` field in the `products` table, including foreign key constraints and indexes for efficient querying.

**API & Module Integration**
- Introduced the `CategoriesModule`, registering it with the main application module and wiring up the controller and service with the `Category` entity. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R25) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R77) [[3]](diffhunk://#diff-84371f5d245cfdb1597f5342be40c1817d478aa63d866ad24c8e235e500734b7R1-R13)
- Implemented a feature-rich `CategoriesController` providing endpoints for creating, updating, activating/deactivating, deleting, and querying categories (including tree structure, descendants, and path), with comprehensive Swagger documentation and authentication guards where needed.

**DTOs & Query Validation**
- Added `CategoryQueryDto` and related DTOs to support advanced filtering, pagination, sorting, and validation for category queries, including options for hierarchical queries and product counts.